### PR TITLE
change df check to nrow(mat)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,13 +3,13 @@ Type: Package
 Title: Create Parameters for Simulation with Uncertainty
 Version: 0.0.1.9002
 Author: Metrum Research Group
-Maintainer: The package maintainer <yourself@somewhere.net>
+Maintainer: Kyle Baron <kyleb@metrumrg.com>
 Description: Given the parameter estimates of a mixed effect model, this 
     function generates sets of parameters for simulation.  Each set takes into 
     account the relevant variance-covariance structure of the fixed effects and 
     random effects.  Two levels of random effects are supported, following the 
     naming conventions of NONMEM.
-License: GPL
+License: GPL (>=2)
 Imports: MASS
 Suggests: testthat, metrumrg
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
 # simpar (development version)
 
-* Added a `NEWS.md` file to track changes to the package.
+* Add a `NEWS.md` file to track changes to the package

--- a/R/simpar.R
+++ b/R/simpar.R
@@ -112,8 +112,8 @@ simpar <- function(nsim,theta,covar,omega,sigma,odf=NULL,sdf=NULL,digits=4,min=-
   if( any(sapply(sigma,function(x)det(x)<0)))stop('not all sigma blocks are positive-definite')
   if(length(odf)!=length(omega))stop('length odf differs from length omega')
   if(length(sdf)!=length(sigma))stop('length sdf differs from length sigma')
-  if(any(odf < sapply(omega,length)))stop('odf[n] is less than number of elements in corresponding matrix')
-  if(any(sdf < sapply(sigma,length)))stop('sdf[n] is less than number of elements in corresponding matrix')
+  if(any(odf < sapply(omega,nrow)))stop('odf[n] is less than number of rows in corresponding matrix')
+  if(any(sdf < sapply(sigma,nrow)))stop('sdf[n] is less than number of rows in corresponding matrix')
   mvr <- mvrnorm(nsim,theta,covar)
   if(nsim==1)mvr <- t(as.matrix(mvr))
   omg <- lapply(1:length(odf),function(x)list(n=nsim,df=odf[[x]],cov=omega[[x]]))
@@ -160,7 +160,7 @@ ord.matrix <- function(x,...){
 
 rinvchisq <- function(n,df,cov) df*as.vector(cov)/rchisq(n, df)
 simblock <- function(n,df,cov){
-  if(df < length(cov))stop('df is less than matrix length')
+  if(df < nrow(cov))stop('df is less than number of rows in matrix')
   if(length(cov)==1)return(rinvchisq(n,df,cov))
   s <- dim(cov)[1]
   ncols <- s*(s+1)/2

--- a/tests/testthat/test-simpar.R
+++ b/tests/testthat/test-simpar.R
@@ -139,6 +139,7 @@ test_that("simulated parameters respect bounds", {
 })
 
 test_that("outputs match metrumrg implementation", {
+  skip_if_not_installed("metrumrg")
   theta <- c(1,2,3,4,5)/10
   covar <- diag(0.1, 5)/seq(1,5)
   omega <- diag(c(1,2,3,4))

--- a/tests/testthat/test-simpar.R
+++ b/tests/testthat/test-simpar.R
@@ -149,3 +149,16 @@ test_that("outputs match metrumrg implementation", {
   b <- metrumrg::simpar(100, theta, covar, omega, sigma)
   expect_identical(a,b)
 })
+
+test_that("minimum degrees of freedom is nrow", {
+  theta <- c(1,2,3,4,5)/10
+  covar <- diag(0.1, 5)/seq(1,5)
+  omega <- diag(c(1,2,3,4))
+  sigma <- diag(c(10,100))
+  expect_type(simpar(5, theta, covar, omega, sigma),"double")
+  expect_type(simpar(5, theta, covar, omega, sigma, odf = 4), "double")
+  expect_error(
+    simpar(5, theta, covar, omega, sigma, odf = 3),
+    regexp = "less than number of rows"
+  )
+})


### PR DESCRIPTION
# Summary 
- minimum `df` for `simblock()` is now `nrow(matrix)` rather than `length(matrix)`